### PR TITLE
feat: add AI_MODE compatibility

### DIFF
--- a/ESTRUTURA_PROJETO.md
+++ b/ESTRUTURA_PROJETO.md
@@ -136,7 +136,7 @@ GET /api/info            # Informações da API
 FLASK_ENV=development
 SECRET_KEY=chave-secreta
 DATABASE_URL=sqlite:///src/database/app.db
-AI_MODE=demo
+AI_MODEL_TYPE=demo  # ou AI_MODE=demo
 OPENAI_API_KEY=opcional
 HUGGINGFACE_API_KEY=opcional
 ```

--- a/README.md
+++ b/README.md
@@ -131,18 +131,18 @@ npm run dev  # ou pnpm run dev
 **Modo Demo (Padrão):**
 ```bash
 # No arquivo claudia-ai-backend/.env
-AI_MODE=demo
+AI_MODEL_TYPE=demo  # ou AI_MODE=demo
 ```
 
 **OpenAI:**
 ```bash
-AI_MODE=openai
+AI_MODEL_TYPE=openai  # ou AI_MODE=openai
 OPENAI_API_KEY=sua-chave-aqui
 ```
 
 **Hugging Face:**
 ```bash
-AI_MODE=huggingface
+AI_MODEL_TYPE=huggingface  # ou AI_MODE=huggingface
 HUGGINGFACE_API_KEY=sua-chave-aqui
 ```
 
@@ -189,7 +189,7 @@ cd claudia-ai-frontend && npm run build
 FLASK_ENV=development
 SECRET_KEY=sua-chave-secreta
 DATABASE_URL=sqlite:///src/database/app.db
-AI_MODE=demo
+AI_MODEL_TYPE=demo  # ou AI_MODE=demo
 OPENAI_API_KEY=opcional
 HUGGINGFACE_API_KEY=opcional
 ```

--- a/claudia-ai-backend/src/routes/ai.py
+++ b/claudia-ai-backend/src/routes/ai.py
@@ -171,8 +171,10 @@ def get_ai_config():
     """Retorna configuração atual da IA"""
     try:
         import os
+        # AI_MODEL_TYPE é preferencial. AI_MODE permanece por compatibilidade.
+        model_type = os.getenv('AI_MODEL_TYPE') or os.getenv('AI_MODE', 'demo')
         config = {
-            'model_type': os.getenv('AI_MODEL_TYPE', 'demo'),
+            'model_type': model_type,
             'model_name': os.getenv('AI_MODEL_NAME', 'demo'),
             'openai_configured': bool(os.getenv('OPENAI_API_KEY')),
             'hf_model': os.getenv('HF_MODEL_NAME', 'microsoft/DialoGPT-medium'),

--- a/claudia-ai-backend/src/services/ai_service.py
+++ b/claudia-ai-backend/src/services/ai_service.py
@@ -7,7 +7,9 @@ logger = logging.getLogger(__name__)
 
 class AIService:
     def __init__(self):
-        self.model_type = os.getenv('AI_MODEL_TYPE', 'demo')
+        # AI_MODEL_TYPE é a variável principal. AI_MODE é mantida por
+        # compatibilidade retroativa.
+        self.model_type = os.getenv('AI_MODEL_TYPE') or os.getenv('AI_MODE', 'demo')
         self.model_name = os.getenv('AI_MODEL_NAME', 'demo')
         self.model = None
         self.tokenizer = None

--- a/docs/GUIA_COMPLETO_INSTALACAO_CLAUDIA_AI.md
+++ b/docs/GUIA_COMPLETO_INSTALACAO_CLAUDIA_AI.md
@@ -441,7 +441,8 @@ SECRET_KEY=chave-super-secreta # Chave de segurança forte
 **Configurações de IA:**
 ```bash
 # Modo de operação da IA
-AI_MODE=demo                  # demo, openai, huggingface, local
+AI_MODEL_TYPE=demo            # demo, openai, huggingface, local
+# AI_MODE também é aceito para compatibilidade
 
 # Configurações OpenAI
 OPENAI_API_KEY=sk-...         # Sua chave da OpenAI
@@ -859,8 +860,8 @@ curl https://api-inference.huggingface.co/models/microsoft/DialoGPT-large \
 **Modo demo não funciona**
 ```bash
 # Verificar configuração
-grep AI_MODE claudia-ai-backend/.env
-# Deve ser: AI_MODE=demo
+grep AI_MODEL_TYPE claudia-ai-backend/.env
+# Deve ser: AI_MODEL_TYPE=demo (AI_MODE também aceito)
 
 # Reiniciar backend
 pkill -f python

--- a/scripts/install-claudia-ai.sh
+++ b/scripts/install-claudia-ai.sh
@@ -276,7 +276,8 @@ SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')
 DATABASE_URL=sqlite:///src/database/app.db
 
 # Configurações da IA (opcional - modo demo por padrão)
-AI_MODE=demo
+AI_MODEL_TYPE=demo
+# AI_MODE=demo  # legado compatível
 # OPENAI_API_KEY=sua-chave-openai-aqui
 # HUGGINGFACE_API_KEY=sua-chave-huggingface-aqui
 


### PR DESCRIPTION
## Summary
- allow backend to read legacy `AI_MODE` env var alongside `AI_MODEL_TYPE`
- document new `AI_MODEL_TYPE` variable and legacy support

## Testing
- `python -m py_compile claudia-ai-backend/src/services/ai_service.py claudia-ai-backend/src/routes/ai.py`
- `curl -s http://localhost:5000/ai/status` (backend launched with `AI_MODE=huggingface`, fell back to demo)


------
https://chatgpt.com/codex/tasks/task_e_689240b4c434832e8666a1e8bd21be8f