### PR TITLE
feat: add huggingface auth token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ AI_MODE=huggingface
 HUGGINGFACE_API_KEY=sua-chave-aqui
 ```
 
+> O token definido em `HUGGINGFACE_API_KEY` é necessário para carregar modelos privados do Hugging Face.
+
 ## 🛠️ Desenvolvimento
 
 ### Comandos Úteis
@@ -191,7 +193,7 @@ SECRET_KEY=sua-chave-secreta
 DATABASE_URL=sqlite:///src/database/app.db
 AI_MODE=demo
 OPENAI_API_KEY=opcional
-HUGGINGFACE_API_KEY=opcional
+HUGGINGFACE_API_KEY=opcional # necessário para modelos privados do Hugging Face
 ```
 
 **Frontend (.env):**

--- a/claudia-ai-backend/src/services/ai_service.py
+++ b/claudia-ai-backend/src/services/ai_service.py
@@ -71,11 +71,19 @@ class AIService:
         try:
             from transformers import AutoTokenizer, AutoModelForCausalLM
             import torch
-            
+
             model_name = os.getenv('HF_MODEL_NAME', 'microsoft/DialoGPT-medium')
-            
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = AutoModelForCausalLM.from_pretrained(model_name)
+
+            hf_token = os.getenv('HUGGINGFACE_API_KEY')
+
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                model_name,
+                use_auth_token=hf_token
+            )
+            self.model = AutoModelForCausalLM.from_pretrained(
+                model_name,
+                use_auth_token=hf_token
+            )
             
             # Configurar para GPU se disponível
             if torch.cuda.is_available():


### PR DESCRIPTION
## Summary
- pass `HUGGINGFACE_API_KEY` to Hugging Face model and tokenizer loading
- document need for token when using private models

## Testing
- `pytest`
- `python - <<'PY'
import os
from transformers import AutoTokenizer

os.environ['HUGGINGFACE_API_KEY'] = os.getenv('HUGGINGFACE_API_KEY', 'dummy')
try:
    AutoTokenizer.from_pretrained('meta-llama/Llama-2-7b-hf', use_auth_token=os.environ['HUGGINGFACE_API_KEY'])
    print('Tokenizer loaded')
except Exception as e:
    print('Failed:', e)
PY` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689240b62a20832ea21e791580da7962